### PR TITLE
Fix empty alpha_list for Exact interpolation model

### DIFF
--- a/batch_checkpoint_merger/main.py
+++ b/batch_checkpoint_merger/main.py
@@ -127,7 +127,7 @@ def get_alpha_list(batch_start, interp_model, nbr_steps, step_size):
         return list(alpha_range_0), list(map(smootherstep, alpha_range))
     if interp_model == 'SmoothestStep':
         return list(alpha_range_0), list(map(smootheststep, alpha_range))
-    return list(alpha_range_0), list(alpha_range_0)
+    return list(alpha_range_0), list(alpha_range)
 
 
 def get_filenames(folder):


### PR DESCRIPTION
When using the `Exact` interpolation model, `get_alpha_list` returns only 1 populated list. This leaves `alpha_list` empty, resulting in no checkpoints being created as it is `alpha_list` that gets iterated over in `merge_models` to do so.